### PR TITLE
Prevent invalid API requests

### DIFF
--- a/src/routes/projects/new.svelte
+++ b/src/routes/projects/new.svelte
@@ -238,7 +238,7 @@
       return;
     }
 
-    if ($project.id != null) {
+    if ($project.id != null && typeof activityID == 'number') {
       try {
         await api.json(api.del(`/projects/${$project.id}/activities/${activityID}`));
         $project.activities = $project.activities.filter(act => act.id !== activityID);


### PR DESCRIPTION
Closes #197
This also manages to sort out the issue of not being able to create an activity (apparently, it was a chain of unfortunate events that was cut down at the root).