### PR TITLE
Change "discard" button behavior

### DIFF
--- a/src/components/projects/new/edit-activity-card.svelte
+++ b/src/components/projects/new/edit-activity-card.svelte
@@ -89,6 +89,7 @@
 
   function discardChanges() {
     activity = copyActivityInPlace(initialCopy, activity);
+    activity._editing = false;
   }
 
   async function saveChanges() {


### PR DESCRIPTION
To return the activity card to the normal (not editing) state.

Based on user feedback